### PR TITLE
Allow users to add mountains

### DIFF
--- a/client/src/components/App.tsx
+++ b/client/src/components/App.tsx
@@ -29,6 +29,7 @@ import AdminStates from './adminPanel/AdminStates';
 import AdminUsers from './adminPanel/AdminUsers';
 import Dashboard from './dashboard';
 import LoginPage from './login';
+import CreateMountain from './mountains/create';
 import MountainDetailPage from './mountains/detail';
 import ListMountainsPage from './mountains/list';
 import ComparePeakListPage from './peakLists/compare';
@@ -39,7 +40,6 @@ import Header from './sharedComponents/Header';
 import UserProfile from './users/detail';
 import ListUsersPage from './users/list';
 import UserSettings from './users/settings';
-import CreateMountain from './mountains/create';
 
 const overlayPortalZIndex = 3000;
 

--- a/client/src/components/App.tsx
+++ b/client/src/components/App.tsx
@@ -39,6 +39,7 @@ import Header from './sharedComponents/Header';
 import UserProfile from './users/detail';
 import ListUsersPage from './users/list';
 import UserSettings from './users/settings';
+import CreateMountain from './mountains/create';
 
 const overlayPortalZIndex = 3000;
 
@@ -156,6 +157,9 @@ const App: React.FC = () => {
         />
         <Route exact path={Routes.ComparePeakListWithMountainDetail}
           render={(props) => <ComparePeakListPage {...props} userId={user._id} />}
+        />
+        <Route exact path={Routes.CreateMountain}
+          render={(props) => <CreateMountain {...props} userId={user._id} />}
         />
         <Route exact path={Routes.PrivacyPolicy} component={PrivacyPolicy} />
         {adminRoutes}

--- a/client/src/components/App.tsx
+++ b/client/src/components/App.tsx
@@ -129,7 +129,12 @@ const App: React.FC = () => {
           render={(props) => <PeakListDetailPage {...props} userId={user._id} />}
         />
         <Route exact path={Routes.MountainSearchWithDetail}
-          render={(props) => <ListMountainsPage {...props} userId={user._id} />}
+          render={(props) => (
+            <ListMountainsPage {...props}
+              userId={user._id}
+              mountainPermissions={user.mountainPermissions}
+            />
+          )}
         />
         <Route exact path={Routes.MountainDetail}
           render={(props) => <MountainDetailPage {...props} userId={user._id} />}
@@ -159,10 +164,20 @@ const App: React.FC = () => {
           render={(props) => <ComparePeakListPage {...props} userId={user._id} />}
         />
         <Route exact path={Routes.CreateMountain}
-          render={(props) => <CreateMountain {...props} userId={user._id} />}
+          render={(props) => (
+            <CreateMountain {...props}
+              userId={user._id}
+              mountainPermissions={user.mountainPermissions}
+            />
+          )}
         />
         <Route exact path={Routes.EditMountain}
-          render={(props) => <CreateMountain {...props} userId={user._id} />}
+          render={(props) => (
+            <CreateMountain {...props}
+              userId={user._id}
+              mountainPermissions={user.mountainPermissions}
+            />
+          )}
         />
         <Route exact path={Routes.PrivacyPolicy} component={PrivacyPolicy} />
         {adminRoutes}
@@ -185,7 +200,12 @@ const App: React.FC = () => {
           render={(props) => <PeakListDetailPage {...props} userId={null} />}
         />
         <Route exact path={Routes.MountainSearchWithDetail}
-          render={(props) => <ListMountainsPage {...props} userId={null} />}
+          render={(props) => (
+            <ListMountainsPage {...props}
+              userId={null}
+              mountainPermissions={null}
+            />
+          )}
         />
         <Route exact path={Routes.MountainDetail}
           render={(props) => <MountainDetailPage {...props} userId={null} />}

--- a/client/src/components/App.tsx
+++ b/client/src/components/App.tsx
@@ -161,6 +161,9 @@ const App: React.FC = () => {
         <Route exact path={Routes.CreateMountain}
           render={(props) => <CreateMountain {...props} userId={user._id} />}
         />
+        <Route exact path={Routes.EditMountain}
+          render={(props) => <CreateMountain {...props} userId={user._id} />}
+        />
         <Route exact path={Routes.PrivacyPolicy} component={PrivacyPolicy} />
         {adminRoutes}
         {/* 404 Route -> */}

--- a/client/src/components/adminPanel/AdminMountains.tsx
+++ b/client/src/components/adminPanel/AdminMountains.tsx
@@ -18,8 +18,8 @@ import AddMountain from './mountains/AddMountain';
 import EditMountain from './mountains/EditMountain';
 import ListMountains from './mountains/ListMountains';
 import {
-  SubNav,
   NavButtonLink,
+  SubNav,
 } from './sharedStyles';
 
 const getMountainsQuery = `
@@ -36,6 +36,8 @@ const getMountainsQuery = `
       }
       author {
         id
+        mountainPermissions
+        email
       }
       flag
       status
@@ -168,7 +170,7 @@ const AdminMountains = () => {
   } else if (mountainsToShow === MountainsToShow.pending) {
     query = GET_PENDING_MOUNTAINS;
   } else {
-    failIfValidOrNonExhaustive(mountainsToShow, 
+    failIfValidOrNonExhaustive(mountainsToShow,
       'Invalid type for mountainsToShow ' + mountainsToShow);
     query = GET_MOUNTAINS;
   }

--- a/client/src/components/adminPanel/AdminUsers.tsx
+++ b/client/src/components/adminPanel/AdminUsers.tsx
@@ -37,6 +37,8 @@ export const GET_USERS = gql`
           id
         }
       }
+      mountainPermissions
+      permissions
     }
   }
 `;
@@ -56,6 +58,8 @@ export interface UserDatum {
   profilePictureUrl: User['profilePictureUrl'];
   friends: User['friends'];
   peakLists: User['peakLists'];
+  mountainPermissions: User['mountainPermissions'];
+  permissions: User['permissions'];
 }
 
 export interface SuccessResponse {

--- a/client/src/components/adminPanel/mountains/AddMountain.tsx
+++ b/client/src/components/adminPanel/mountains/AddMountain.tsx
@@ -1,7 +1,8 @@
 import { useQuery } from '@apollo/react-hooks';
 import gql from 'graphql-tag';
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import { State } from '../../../types/graphQLTypes';
+import { UserContext } from '../../App';
 import { AddMountainVariables } from '../AdminMountains';
 import {
   CreateButton,
@@ -35,6 +36,8 @@ interface Props {
 const AddMountain = (props: Props) => {
   const { addMountain, cancel } = props;
 
+  const user = useContext(UserContext);
+
   const [name, setName] = useState<string>('');
   const [latitude, setLatitude] = useState<number | null>(null);
   const [longitude, setLongitude] = useState<number | null>(null);
@@ -45,7 +48,7 @@ const AddMountain = (props: Props) => {
   const handleSubmit = (e: React.SyntheticEvent) => {
     e.preventDefault();
     if (name !== '' && latitude !== null && longitude !== null
-      && elevation !== null && selectedState !== null) {
+      && elevation !== null && selectedState !== null && user && user._id) {
       addMountain({
         name,
         latitude,
@@ -53,6 +56,7 @@ const AddMountain = (props: Props) => {
         elevation,
         prominence,
         state: selectedState,
+        author: user._id,
       });
     }
     cancel();

--- a/client/src/components/adminPanel/mountains/ListMountains.tsx
+++ b/client/src/components/adminPanel/mountains/ListMountains.tsx
@@ -39,17 +39,18 @@ interface StatusVariables {
   status: CreatedItemStatus | null;
 }
 
-const UPDATE_MOUNTAIN_PERMISSIONS = gql`
+export const UPDATE_MOUNTAIN_PERMISSIONS = gql`
   mutation($id: ID!, $mountainPermissions: Int) {
     user: updateMountainPermissions
     (id: $id, mountainPermissions: $mountainPermissions) {
       id
+      email
       mountainPermissions
     }
   }
 `;
 
-interface PermissionsSuccessResponse {
+export interface PermissionsSuccessResponse {
   user: null | {
     id: User['id'];
     mountainPermissions: User['mountainPermissions'];
@@ -57,7 +58,7 @@ interface PermissionsSuccessResponse {
   };
 }
 
-interface PermissionsVariables {
+export interface PermissionsVariables {
   id: string;
   mountainPermissions: number | null;
 }

--- a/client/src/components/adminPanel/sharedStyles.tsx
+++ b/client/src/components/adminPanel/sharedStyles.tsx
@@ -8,6 +8,14 @@ import {
   LinkButton,
 } from '../../styling/styleUtils';
 
+export const SubNav = styled.nav`
+  display: flex;
+`;
+
+export const NavButtonLink = styled(LinkButton)`
+  margin-right: 1rem;
+`;
+
 const ListItemRoot = styled.div`
   margin: 1rem;
   padding: 1rem;
@@ -45,15 +53,19 @@ interface ListItemProps {
   content: React.ReactNode | null;
   onEdit: () => void;
   onDelete: () => void;
+  titleColor?: string;
 }
 
 export const ListItem = (props: ListItemProps) => {
-  const { title, content, onDelete, onEdit } = props;
+  const { title, content, onDelete, onEdit, titleColor } = props;
 
   return (
     <ListItemRoot>
       <TitleContainer>
-        <Title onClick={onEdit}>
+        <Title
+          onClick={onEdit}
+          style={{color: titleColor}}
+        >
           {title}
         </Title>
       </TitleContainer>

--- a/client/src/components/adminPanel/sharedStyles.tsx
+++ b/client/src/components/adminPanel/sharedStyles.tsx
@@ -51,7 +51,7 @@ const EditButton = styled(ButtonPrimary)`
 interface ListItemProps {
   title: string;
   content: React.ReactNode | null;
-  onEdit: () => void;
+  onEdit: null | (() => void);
   onDelete: () => void;
   titleColor?: string;
 }
@@ -59,21 +59,29 @@ interface ListItemProps {
 export const ListItem = (props: ListItemProps) => {
   const { title, content, onDelete, onEdit, titleColor } = props;
 
+  const editButton = onEdit === null ? null : (
+    <EditButton onClick={onEdit}>
+      Edit
+    </EditButton>
+  );
+
+  const titleEl = onEdit === null ? <strong>{title}</strong> : (
+    <Title
+      onClick={onEdit}
+      style={{color: titleColor}}
+    >
+      {title}
+    </Title>
+  );
+
   return (
     <ListItemRoot>
       <TitleContainer>
-        <Title
-          onClick={onEdit}
-          style={{color: titleColor}}
-        >
-          {title}
-        </Title>
+        {titleEl}
       </TitleContainer>
       {content}
       <ButtonContainer>
-        <EditButton onClick={onEdit}>
-          Edit
-        </EditButton>
+        {editButton}
         <ButtonSecondary onClick={onDelete}>
           Delete
         </ButtonSecondary>

--- a/client/src/components/mountains/create/MountainForm.tsx
+++ b/client/src/components/mountains/create/MountainForm.tsx
@@ -1,0 +1,143 @@
+import React, {useState} from 'react';
+import {
+  ButtonPrimary,
+  ButtonSecondary,
+  InputBase,
+  Label,
+} from '../../../styling/styleUtils';
+import styled from 'styled-components';
+import Map, {CoordinateWithDates} from '../../sharedComponents/map';
+import { PeakListVariants } from '../../../types/graphQLTypes';
+
+const Root = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+`;
+
+const FullColumn = styled.div`
+  grid-column: span 2;
+`;
+
+const longLatMin = -90;
+const longLatMax = 90;
+const elevationMin = 0;
+const elevationMax = 29029; // Height of Everest
+
+const validateIntValue = (value: string, min: number, max: number) => {
+  const parsedValue = parseInt(value, 10);
+  if (isNaN(parsedValue)) {
+    return 0;
+  } else if (parsedValue > max || parsedValue < min) {
+    return 0;
+  } else {
+    return parsedValue;
+  }
+}
+
+const MountainForm = () => {
+
+  const [name, setName] = useState<string>('');
+
+  const [stringLat, setStringLat] = useState<string>('');
+  const [stringLong, setStringLong] = useState<string>('');
+
+  const [stringElevation, setStringElevation] = useState<string>('');
+
+  const latitude: number = validateIntValue(stringLat, longLatMin, longLatMax);
+  const longitude: number = validateIntValue(stringLong, longLatMin, longLatMax);
+  const elevation: number = validateIntValue(stringElevation, elevationMin, elevationMax);
+
+  const coordinate: CoordinateWithDates = {
+    id: '',
+    latitude, longitude,
+    name, elevation,
+    completionDates: null,
+  }
+
+  const map = !isNaN(latitude) && !isNaN(longitude) && !isNaN(elevation)
+    && latitude <= 90 && latitude >= - 90 && longitude <= 90 && longitude >= - 90
+    ? (
+        <Map
+          id={''}
+          coordinates={[coordinate]}
+          highlighted={[coordinate]}
+          peakListType={PeakListVariants.standard}
+          userId={null}
+          isOtherUser={undefined}
+          hideLegend={true}
+          key={'create-mountain-key'}
+        />
+      ) : null;
+
+  return (
+    <Root>
+      <FullColumn>
+        <Label>
+          Mountain Name
+        </Label>
+        <InputBase
+          type={'text'}
+          value={name}
+          onChange={e => setName(e.target.value)}
+        />
+      </FullColumn>
+      <div>
+        <Label>
+          Latitude
+        </Label>
+        <InputBase
+          type={'number'}
+          max={longLatMax}
+          min={longLatMin}
+          value={stringLat}
+          onChange={e => setStringLat(e.target.value)}
+        />
+      </div>
+      <div>
+        <Label>
+          Longitude
+        </Label>
+        <InputBase
+          type={'number'}
+          max={longLatMax}
+          min={longLatMin}
+          value={stringLong}
+          onChange={e => setStringLong(e.target.value)}
+        />
+      </div>
+      <FullColumn>
+        {map}
+      </FullColumn>
+      <div>
+        <Label>
+          State
+        </Label>
+        <InputBase />
+      </div>
+      <div>
+        <Label>
+          Elevation
+        </Label>
+        <InputBase
+          type={'number'}
+          min={elevationMin}
+          max={elevationMax}
+          value={stringElevation}
+          onChange={e => setStringElevation(e.target.value)}
+        />
+      </div>
+
+
+      <FullColumn>
+        <ButtonSecondary>
+          Cancel
+        </ButtonSecondary>
+        <ButtonPrimary>
+          Submit
+        </ButtonPrimary>
+      </FullColumn>
+    </Root>
+  );
+}
+
+export default MountainForm;

--- a/client/src/components/mountains/create/MountainForm.tsx
+++ b/client/src/components/mountains/create/MountainForm.tsx
@@ -1,30 +1,75 @@
-import React, {useState} from 'react';
+import React, {useState, useContext} from 'react';
 import {
   ButtonPrimary,
   ButtonSecondary,
   InputBase,
   Label,
+  SelectBox,
 } from '../../../styling/styleUtils';
 import styled from 'styled-components';
 import Map, {CoordinateWithDates} from '../../sharedComponents/map';
-import { PeakListVariants } from '../../../types/graphQLTypes';
+import { Mountain, PeakListVariants, State } from '../../../types/graphQLTypes';
+import { useQuery } from '@apollo/react-hooks';
+import gql from 'graphql-tag';
+import {
+  AppLocalizationAndBundleContext,
+} from '../../../contextProviders/getFluentLocalizationContext';
+import { GetString } from 'fluent-react';
+import sortBy from 'lodash/sortBy';
 
 const Root = styled.div`
   display: grid;
   grid-template-columns: 1fr 1fr;
+  grid-gap: 1rem;
 `;
 
 const FullColumn = styled.div`
   grid-column: span 2;
 `;
 
+const GET_NEARBY_MOUNTAINS = gql`
+  query getNearbyMountains(
+    $latitude: Float!, $longitude: Float!, $latDistance: Float!, $longDistance: Float!) {
+  mountains: nearbyMountains(
+    latitude: $latitude,
+    longitude: $longitude,
+    latDistance: $latDistance,
+    longDistance: $longDistance,
+  ) {
+    id
+    name
+    latitude
+    longitude
+    elevation
+  }
+}
+`;
+
+interface SuccessResponse {
+  mountains: null | Array<{
+    id: Mountain['id'];
+    name: Mountain['name'];
+    latitude: Mountain['latitude'];
+    longitude: Mountain['longitude'];
+    elevation: Mountain['elevation'];
+  }>
+}
+
+interface Variables {
+  latitude: number;
+  longitude: number;
+  latDistance: number;
+  longDistance: number;
+}
+
+
 const longLatMin = -90;
 const longLatMax = 90;
 const elevationMin = 0;
 const elevationMax = 29029; // Height of Everest
 
-const validateIntValue = (value: string, min: number, max: number) => {
-  const parsedValue = parseInt(value, 10);
+const validateFloatValue = (value: string, min: number, max: number) => {
+  const parsedValue = parseFloat(value);
   if (isNaN(parsedValue)) {
     return 0;
   } else if (parsedValue > max || parsedValue < min) {
@@ -34,7 +79,20 @@ const validateIntValue = (value: string, min: number, max: number) => {
   }
 }
 
-const MountainForm = () => {
+export interface StateDatum {
+  id: State['id'];
+  name: State['name'];
+  abbreviation: State['abbreviation'];
+}
+
+interface Props {
+  states: StateDatum[];
+}
+
+const MountainForm = (props: Props) => {
+  const { states } = props;
+  const {localization} = useContext(AppLocalizationAndBundleContext);
+  const getFluentString: GetString = (...args) => localization.getString(...args);
 
   const [name, setName] = useState<string>('');
 
@@ -42,15 +100,28 @@ const MountainForm = () => {
   const [stringLong, setStringLong] = useState<string>('');
 
   const [stringElevation, setStringElevation] = useState<string>('');
+  const [selectedState, setSelectedState] = useState<State['id'] | null>(null);
 
-  const latitude: number = validateIntValue(stringLat, longLatMin, longLatMax);
-  const longitude: number = validateIntValue(stringLong, longLatMin, longLatMax);
-  const elevation: number = validateIntValue(stringElevation, elevationMin, elevationMax);
+  const latitude: number = validateFloatValue(stringLat, longLatMin, longLatMax);
+  const longitude: number = validateFloatValue(stringLong, longLatMin, longLatMax);
+  const elevation: number = validateFloatValue(stringElevation, elevationMin, elevationMax);
+
+  const {loading, error, data} = useQuery<SuccessResponse, Variables>(GET_NEARBY_MOUNTAINS, {
+    variables: { latitude, longitude, latDistance: 0.1, longDistance: 0.2 },
+  });
+
+  let nearbyMountains: CoordinateWithDates[];
+  if (!loading && !error && data !== undefined && data.mountains) {
+    nearbyMountains = data.mountains.map(mtn => ({...mtn, completionDates: null }));
+  } else {
+    nearbyMountains = [];
+  }
 
   const coordinate: CoordinateWithDates = {
     id: '',
     latitude, longitude,
-    name, elevation,
+    name: name ? name : `[${getFluentString('create-mountain-mountain-name-placeholder')}]`,
+    elevation,
     completionDates: null,
   }
 
@@ -59,64 +130,54 @@ const MountainForm = () => {
     ? (
         <Map
           id={''}
-          coordinates={[coordinate]}
+          coordinates={[coordinate, ...nearbyMountains]}
           highlighted={[coordinate]}
           peakListType={PeakListVariants.standard}
           userId={null}
-          isOtherUser={undefined}
-          hideLegend={true}
+          isOtherUser={true}
+          createOrEditMountain={true}
           key={'create-mountain-key'}
         />
       ) : null;
+
+  const sortedStates = sortBy(states, ['name']);
+  const stateOptions = sortedStates.map(state => {
+    return (
+      <option key={state.id} value={state.id}>
+        {state.name} ({state.abbreviation})
+      </option>
+    );
+  });
 
   return (
     <Root>
       <FullColumn>
         <Label>
-          Mountain Name
+          {getFluentString('create-mountain-mountain-name-placeholder')}
         </Label>
         <InputBase
           type={'text'}
           value={name}
           onChange={e => setName(e.target.value)}
+          placeholder={getFluentString('create-mountain-mountain-name-placeholder')}
         />
       </FullColumn>
       <div>
         <Label>
-          Latitude
+          {getFluentString('global-text-value-state')}
         </Label>
-        <InputBase
-          type={'number'}
-          max={longLatMax}
-          min={longLatMin}
-          value={stringLat}
-          onChange={e => setStringLat(e.target.value)}
-        />
+        <SelectBox
+          value={`${selectedState || ''}`}
+          onChange={e => setSelectedState(e.target.value)}
+          placeholder={getFluentString('create-mountain-select-a-state')}
+        >
+          <option value='' key='empty-option-to-select'></option>
+          {stateOptions}
+        </SelectBox>
       </div>
       <div>
         <Label>
-          Longitude
-        </Label>
-        <InputBase
-          type={'number'}
-          max={longLatMax}
-          min={longLatMin}
-          value={stringLong}
-          onChange={e => setStringLong(e.target.value)}
-        />
-      </div>
-      <FullColumn>
-        {map}
-      </FullColumn>
-      <div>
-        <Label>
-          State
-        </Label>
-        <InputBase />
-      </div>
-      <div>
-        <Label>
-          Elevation
+          {getFluentString('global-text-value-elevation')}
         </Label>
         <InputBase
           type={'number'}
@@ -124,10 +185,35 @@ const MountainForm = () => {
           max={elevationMax}
           value={stringElevation}
           onChange={e => setStringElevation(e.target.value)}
+          placeholder={getFluentString('create-mountain-elevation-placeholder')}
         />
       </div>
-
-
+      <div>
+        <Label>
+          {getFluentString('global-text-value-latitude')}
+        </Label>
+        <InputBase
+          type={'number'}
+          max={longLatMax}
+          min={longLatMin}
+          value={stringLat}
+          onChange={e => setStringLat(e.target.value)}
+          placeholder={getFluentString('create-mountain-latitude-placeholder')}
+        />
+      </div>
+      <div>
+        <Label>
+          {getFluentString('global-text-value-longitude')}
+        </Label>
+        <InputBase
+          type={'number'}
+          max={longLatMax}
+          min={longLatMin}
+          value={stringLong}
+          onChange={e => setStringLong(e.target.value)}
+          placeholder={getFluentString('create-mountain-longitude-placeholder')}
+        />
+      </div>
       <FullColumn>
         <ButtonSecondary>
           Cancel
@@ -135,6 +221,12 @@ const MountainForm = () => {
         <ButtonPrimary>
           Submit
         </ButtonPrimary>
+      </FullColumn>
+      <FullColumn>
+        <p>
+          {getFluentString('create-mountain-check-your-work')}
+        </p>
+        {map}
       </FullColumn>
     </Root>
   );

--- a/client/src/components/mountains/create/MountainForm.tsx
+++ b/client/src/components/mountains/create/MountainForm.tsx
@@ -105,7 +105,7 @@ export interface StateDatum {
   abbreviation: State['abbreviation'];
 }
 
-interface InitialMountainDatum {
+export interface InitialMountainDatum {
   id: Mountain['id'];
   name: Mountain['name'];
   latitude: string;
@@ -148,7 +148,8 @@ const MountainForm = (props: Props) => {
 
   let nearbyMountains: CoordinateWithDates[];
   if (!loading && !error && data !== undefined && data.mountains) {
-    nearbyMountains = data.mountains.map(mtn => ({...mtn, completionDates: null }));
+    const filteredMountains = data.mountains.filter(mtn => mtn.id !== initialData.id);
+    nearbyMountains = filteredMountains.map(mtn => ({...mtn, completionDates: null }));
   } else {
     nearbyMountains = [];
   }
@@ -207,10 +208,14 @@ const MountainForm = (props: Props) => {
   const saveButtonText = loadingSubmit === true
     ? getFluentString('global-text-value-saving') + '...' : getFluentString('global-text-value-save');
 
+  const titleText = initialData.name !== '' ? getFluentString('create-mountain-title-edit', {
+    'mountain-name': initialData.name,
+  }) : getFluentString('create-mountain-title-create');
+
   return (
     <Root>
       <FullColumn>
-        <h1>{getFluentString('create-mountain-title-create')}</h1>
+        <h1>{titleText}</h1>
       </FullColumn>
       <FullColumn>
         <label htmlFor={'create-mountain-name'}>

--- a/client/src/components/mountains/create/MountainForm.tsx
+++ b/client/src/components/mountains/create/MountainForm.tsx
@@ -85,22 +85,34 @@ export interface StateDatum {
   abbreviation: State['abbreviation'];
 }
 
+interface InitialMountainDatum {
+  id: Mountain['id'];
+  name: Mountain['name'];
+  latitude: string;
+  longitude: string;
+  elevation: string;
+  state: null | { id: State['id']};
+}
+
 interface Props {
   states: StateDatum[];
+  initialData: InitialMountainDatum;
 }
 
 const MountainForm = (props: Props) => {
-  const { states } = props;
+  const { states, initialData } = props;
   const {localization} = useContext(AppLocalizationAndBundleContext);
   const getFluentString: GetString = (...args) => localization.getString(...args);
 
-  const [name, setName] = useState<string>('');
+  const [name, setName] = useState<string>(initialData.name);
 
-  const [stringLat, setStringLat] = useState<string>('');
-  const [stringLong, setStringLong] = useState<string>('');
+  const [stringLat, setStringLat] = useState<string>(initialData.latitude);
+  const [stringLong, setStringLong] = useState<string>(initialData.longitude);
 
-  const [stringElevation, setStringElevation] = useState<string>('');
-  const [selectedState, setSelectedState] = useState<State['id'] | null>(null);
+  const [stringElevation, setStringElevation] = useState<string>(initialData.elevation);
+  const [selectedState, setSelectedState] = useState<State['id'] | null>(
+    initialData.state === null ? null : initialData.state.id
+  );
 
   const latitude: number = validateFloatValue(stringLat, longLatMin, longLatMax);
   const longitude: number = validateFloatValue(stringLong, longLatMin, longLatMax);
@@ -151,6 +163,9 @@ const MountainForm = (props: Props) => {
 
   return (
     <Root>
+      <FullColumn>
+        <h1>{getFluentString('create-mountain-title-create')}</h1>
+      </FullColumn>
       <FullColumn>
         <Label>
           {getFluentString('create-mountain-mountain-name-placeholder')}

--- a/client/src/components/mountains/create/index.tsx
+++ b/client/src/components/mountains/create/index.tsx
@@ -6,6 +6,7 @@ import {
   ContentLeftLarge,
 } from '../../../styling/Grid';
 import BackButton from '../../sharedComponents/BackButton';
+import MountainForm from './MountainForm';
 
 interface Props extends RouteComponentProps {
   userId: string | null;
@@ -23,6 +24,7 @@ const MountainCreatePage = (props: Props) => {
         </ContentHeader>
         <ContentBody>
           User ID: {userId}, Mountain ID: {id}
+          <MountainForm />
         </ContentBody>
       </ContentLeftLarge>
     </>

--- a/client/src/components/mountains/create/index.tsx
+++ b/client/src/components/mountains/create/index.tsx
@@ -55,9 +55,18 @@ const MountainCreatePage = (props: Props) => {
     );
   } else if (data !== undefined) {
     const states = data.states ? data.states : [];
+    const initialMountain = {
+      id: '',
+      name: '',
+      latitude: '',
+      longitude: '',
+      elevation: '',
+      state: null,
+    }
     mountainForm = (
       <MountainForm
         states={states}
+        initialData={initialMountain}
       />
     );
   } else {

--- a/client/src/components/mountains/create/index.tsx
+++ b/client/src/components/mountains/create/index.tsx
@@ -33,6 +33,7 @@ const GET_MOUNTAIN_AND_STATES = gql`
       author {
         id
       }
+      flag
     }
     states {
       id
@@ -65,6 +66,7 @@ const ADD_MOUNTAIN = gql`
       author {
         id
       }
+      flag
     }
   }
 `;
@@ -91,6 +93,7 @@ const EDIT_MOUNTAIN = gql`
       author {
         id
       }
+      flag
     }
   }
 `;
@@ -108,6 +111,7 @@ interface MountainSuccessResponse {
     author: null | {
       id: User['id'];
     }
+    flag: Mountain['flag'];
   };
 }
 
@@ -165,7 +169,7 @@ const MountainCreatePage = (props: Props) => {
 
     let initialMountain: InitialMountainDatum;
     if (data.mountain && data.mountain.author && data.mountain.author.id === userId) {
-      const {mountain: {name, state}, mountain} = data;
+      const {mountain: {name, state, flag}, mountain} = data;
       const stringLat = mountain.latitude.toString();
       const stringLong = mountain.longitude.toString();
       const stringElevation = mountain.elevation.toString();
@@ -175,7 +179,7 @@ const MountainCreatePage = (props: Props) => {
         latitude: stringLat,
         longitude: stringLong,
         elevation: stringElevation,
-        state,
+        state, flag,
       };
     } else {
       initialMountain = {
@@ -185,6 +189,7 @@ const MountainCreatePage = (props: Props) => {
         longitude: '',
         elevation: '',
         state: null,
+        flag: null,
       };
     }
 

--- a/client/src/components/mountains/create/index.tsx
+++ b/client/src/components/mountains/create/index.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { RouteComponentProps, withRouter } from 'react-router';
+import {
+  ContentBody,
+  ContentHeader,
+  ContentLeftLarge,
+} from '../../../styling/Grid';
+import BackButton from '../../sharedComponents/BackButton';
+
+interface Props extends RouteComponentProps {
+  userId: string | null;
+}
+
+const MountainCreatePage = (props: Props) => {
+  const { userId, match } = props;
+  const { id }: any = match.params;
+
+  return (
+    <>
+      <ContentLeftLarge>
+        <ContentHeader>
+          <BackButton />
+        </ContentHeader>
+        <ContentBody>
+          User ID: {userId}, Mountain ID: {id}
+        </ContentBody>
+      </ContentLeftLarge>
+    </>
+  );
+};
+
+export default withRouter(MountainCreatePage);

--- a/client/src/components/mountains/detail/FlagModal.tsx
+++ b/client/src/components/mountains/detail/FlagModal.tsx
@@ -1,0 +1,128 @@
+import { useMutation } from '@apollo/react-hooks';
+import { GetString } from 'fluent-react';
+import React, { useContext, useState } from 'react';
+import {
+  AppLocalizationAndBundleContext,
+} from '../../../contextProviders/getFluentLocalizationContext';
+import { ButtonPrimary, Label, SelectBox } from '../../../styling/styleUtils';
+import { MountainFlag } from '../../../types/graphQLTypes';
+import {
+  ButtonWrapper,
+  CancelButton,
+} from '../../sharedComponents/AreYouSureModal';
+import Modal from '../../sharedComponents/Modal';
+import {
+  FLAG_MOUNTAIN,
+  FlagSuccessResponse,
+  FlagVariables,
+} from '../create/MountainForm';
+
+interface Props {
+  onClose: () => void;
+  mountainName: string;
+  mountainId: string;
+}
+
+const FlagModal = (props: Props) => {
+  const { onClose, mountainId, mountainName } = props;
+
+  const {localization} = useContext(AppLocalizationAndBundleContext);
+  const getFluentString: GetString = (...args) => localization.getString(...args);
+
+  const [updateMountainFlag] = useMutation<FlagSuccessResponse, FlagVariables>(FLAG_MOUNTAIN);
+
+  const [flag, setFlag] = useState<MountainFlag | ''>('');
+  const [flagSubmitted, setFlagSubmitted] = useState<boolean>(false);
+
+  const onSubmit = () => {
+    if (mountainId && flag) {
+      updateMountainFlag({variables: {id: mountainId, flag}});
+    }
+    setFlagSubmitted(true);
+  };
+
+  const actions = flagSubmitted === false ? (
+    <ButtonWrapper>
+      <CancelButton onClick={onClose}>
+        {getFluentString('global-text-value-modal-close')}
+      </CancelButton>
+      <ButtonPrimary onClick={onSubmit}>
+        {getFluentString('global-text-value-submit')}
+      </ButtonPrimary>
+    </ButtonWrapper>
+  ) : (
+    <ButtonWrapper>
+      <CancelButton onClick={onClose}>
+        {getFluentString('global-text-value-modal-close')}
+      </CancelButton>
+    </ButtonWrapper>
+  );
+
+  const text = flagSubmitted === false
+    ? getFluentString('flag-mountain-text') : getFluentString('flag-mountain-thanks');
+
+  const flagOptions = flagSubmitted === false ? (
+    <>
+      <Label>{getFluentString('flag-mountain-select-issue')}</Label>
+      <SelectBox
+        id={'create-mountain-select-a-state'}
+        value={flag}
+        onChange={(e) => setFlag(e.target.value as MountainFlag | '')}
+        placeholder={getFluentString('create-mountain-select-a-state')}
+      >
+        <option value={''} key='empty-option-to-select'></option>
+        <option value={MountainFlag.location} key='location'>
+          {getFluentString('flag-mountain-select-issue-description', {
+            issue: MountainFlag.location,
+          })}
+        </option>
+        <option value={MountainFlag.elevation} key='elevation'>
+          {getFluentString('flag-mountain-select-issue-description', {
+            issue: MountainFlag.elevation,
+          })}
+        </option>
+        <option value={MountainFlag.state} key='state'>
+          {getFluentString('flag-mountain-select-issue-description', {
+            issue: MountainFlag.state,
+          })}
+        </option>
+        <option value={MountainFlag.duplicate} key='duplicate'>
+          {getFluentString('flag-mountain-select-issue-description', {
+            issue: MountainFlag.duplicate,
+          })}
+        </option>
+        <option value={MountainFlag.data} key='data'>
+          {getFluentString('flag-mountain-select-issue-description', {
+            issue: MountainFlag.data,
+          })}
+        </option>
+        <option value={MountainFlag.abuse} key='abuse'>
+          {getFluentString('flag-mountain-select-issue-description', {
+            issue: MountainFlag.abuse,
+          })}
+        </option>
+        <option value={MountainFlag.other} key='other'>
+          {getFluentString('flag-mountain-select-issue-description', {
+            issue: MountainFlag.other,
+          })}
+        </option>
+      </SelectBox>
+    </>
+  ) : null;
+
+  return (
+    <Modal
+      actions={actions}
+      onClose={onClose}
+      width={'600px'}
+      height={'auto'}
+    >
+      <h3>{getFluentString('flag-mountain-title', {name: mountainName})}</h3>
+      <p>{text}</p>
+      {flagOptions}
+
+    </Modal>
+  );
+};
+
+export default FlagModal;

--- a/client/src/components/mountains/detail/MountainDetail.tsx
+++ b/client/src/components/mountains/detail/MountainDetail.tsx
@@ -7,21 +7,22 @@ import {
   AppLocalizationAndBundleContext,
 } from '../../../contextProviders/getFluentLocalizationContext';
 import { CaltopoLink, GoogleMapsLink } from '../../../routing/externalLinks';
+import { editMountainLink } from '../../../routing/Utils';
 import {
-  lightBorderColor,
-  PlaceholderText,
-  ButtonSecondary,
+  ButtonSecondaryLink,
   GhostButton,
+  lightBorderColor,
   lowWarningColorDark,
+  PlaceholderText,
 } from '../../../styling/styleUtils';
 import {
+  CreatedItemStatus,
   Mountain,
   PeakList,
   PeakListVariants,
   Region,
   State,
   User,
-  CreatedItemStatus,
 } from '../../../types/graphQLTypes';
 import { convertDMS, mobileSize } from '../../../Utils';
 import {
@@ -321,12 +322,12 @@ const MountainDetail = (props: Props) => {
       };
 
       const actionButton = author && author.id && author.id === userId ? (
-        <ButtonSecondary>
-          Edit Mountain
-        </ButtonSecondary>
+        <ButtonSecondaryLink to={editMountainLink(mountain.id)}>
+          {getFluentString('global-text-value-edit')}
+        </ButtonSecondaryLink>
       ) : (
         <GhostButton>
-          Flag Mountain
+          {getFluentString('global-text-value-flag')}
         </GhostButton>
       );
 

--- a/client/src/components/mountains/detail/MountainDetail.tsx
+++ b/client/src/components/mountains/detail/MountainDetail.tsx
@@ -151,6 +151,7 @@ const GET_MOUNTAIN_DETAIL = gql`
         id
         text
       }
+      mountainPermissions
     }
   }
 `;
@@ -180,6 +181,7 @@ interface QuerySuccessResponse {
     id: User['name'];
     mountains: User['mountains'];
     mountainNote: User['mountainNote'];
+    mountainPermissions: User['mountainPermissions'];
   };
 }
 
@@ -325,7 +327,8 @@ const MountainDetail = (props: Props) => {
         }
       };
 
-      const actionButton = author && author.id && author.id === userId ? (
+      const actionButton = author && author.id && author.id === userId
+        && user && user.mountainPermissions !== -1 ? (
         <ButtonSecondaryLink to={editMountainLink(mountain.id)}>
           {getFluentString('global-text-value-edit')}
         </ButtonSecondaryLink>

--- a/client/src/components/mountains/detail/MountainDetail.tsx
+++ b/client/src/components/mountains/detail/MountainDetail.tsx
@@ -1,7 +1,7 @@
 import { useMutation, useQuery } from '@apollo/react-hooks';
 import { GetString } from 'fluent-react';
 import gql from 'graphql-tag';
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 import styled from 'styled-components/macro';
 import {
   AppLocalizationAndBundleContext,
@@ -33,6 +33,7 @@ import LoadingSpinner from '../../sharedComponents/LoadingSpinner';
 import Map from '../../sharedComponents/map';
 import UserNote from '../../sharedComponents/UserNote';
 import AscentsList from './AscentsList';
+import FlagModal from './FlagModal';
 import IncludedLists from './IncludedLists';
 import LocalTrails from './LocalTrails';
 import {
@@ -250,6 +251,9 @@ const MountainDetail = (props: Props) => {
   const [addMountainNote] = useMutation<MountainNoteSuccess, MountainNoteVariables>(ADD_MOUNTAIN_NOTE);
   const [editMountainNote] = useMutation<MountainNoteSuccess, MountainNoteVariables>(EDIT_MOUNTAIN_NOTE);
 
+  const [isFlagModalOpen, setIsFlagModalOpen] = useState<boolean>(false);
+  const closeFlagModal = () => setIsFlagModalOpen(false);
+
   if (loading === true) {
     return <LoadingSpinner />;
   } else if (error !== undefined) {
@@ -326,9 +330,17 @@ const MountainDetail = (props: Props) => {
           {getFluentString('global-text-value-edit')}
         </ButtonSecondaryLink>
       ) : (
-        <GhostButton>
+        <GhostButton onClick={() => setIsFlagModalOpen(true)}>
           {getFluentString('global-text-value-flag')}
         </GhostButton>
+      );
+
+      const flagModal = isFlagModalOpen === false ? null : (
+        <FlagModal
+          onClose={closeFlagModal}
+          mountainId={mountain.id}
+          mountainName={mountain.name}
+        />
       );
 
       return (
@@ -402,6 +414,7 @@ const MountainDetail = (props: Props) => {
             mountainName={name}
             getFluentString={getFluentString}
           />
+          {flagModal}
         </>
       );
     }

--- a/client/src/components/mountains/detail/TripReports.tsx
+++ b/client/src/components/mountains/detail/TripReports.tsx
@@ -48,6 +48,10 @@ const ReadFullReportButton = styled(GhostButton)`
   visibility: hidden;
 `;
 
+const Text = styled.div`
+  white-space: pre-wrap;
+`;
+
 export const nPerPage = 7;
 
 export const GET_LATEST_TRIP_REPORTS_FOR_MOUNTAIN = gql`
@@ -173,8 +177,12 @@ const TripReports = ({mountainId, mountainName}: Props) => {
   } else if (data !== undefined) {
     const { tripReports } = data;
     if (tripReports.length) {
-
-      const reportList = tripReports.map(report => {
+      // max character array setup to map to same order as trip report list
+      // the first and second reports, n[0] and n[1], should show more characters
+      // the rest should show only 250
+      const maxCharactersArray = [1000, 500];
+      const maxCharactersDefault = 250;
+      const reportList = tripReports.map((report, i) => {
         const allConditionsArray: string[] = [];
         Object.keys(report).forEach(function(key: keyof TripReport) {
           if (isCondition(key) && report[key]) {
@@ -228,9 +236,9 @@ const TripReports = ({mountainId, mountainName}: Props) => {
             </Section>
           );
         }
-        const maxCharacters = 250;
         let notes: React.ReactElement<any> | null;
         if (report.notes && report.notes.length) {
+          const maxCharacters = i <= 1 ? maxCharactersArray[i] : maxCharactersDefault;
           const text = report.notes.substring(0, maxCharacters);
           const readMoreText = report.notes.length > maxCharacters ? (
             <>
@@ -243,9 +251,9 @@ const TripReports = ({mountainId, mountainName}: Props) => {
               <SectionTitle>
                 {getFluentString('trip-report-notes-title')}
               </SectionTitle>
-              <div>
+              <Text>
                 {text}{readMoreText}
-              </div>
+              </Text>
             </Section>
           );
         } else {

--- a/client/src/components/mountains/detail/TripReports.tsx
+++ b/client/src/components/mountains/detail/TripReports.tsx
@@ -210,14 +210,14 @@ const TripReports = ({mountainId, mountainName}: Props) => {
           );
         } else {
           const conditionsText: Array<React.ReactElement<any>> = [];
-          allConditionsArray.forEach((condition, i) => {
-            if (i === allConditionsArray.length - 2) {
+          allConditionsArray.forEach((condition, j) => {
+            if (j === allConditionsArray.length - 2) {
               conditionsText.push(
                 <React.Fragment  key={condition + report.id}>
                   <Condition>{condition}</Condition>{' and '}
                 </React.Fragment>,
               );
-            } else if (i === allConditionsArray.length - 1) {
+            } else if (j === allConditionsArray.length - 1) {
               conditionsText.push(
                 <Condition key={condition + report.id}>{condition}</Condition>,
               );

--- a/client/src/components/mountains/detail/TripReports.tsx
+++ b/client/src/components/mountains/detail/TripReports.tsx
@@ -278,7 +278,7 @@ const TripReports = ({mountainId, mountainName}: Props) => {
         );
 
         return (
-          <ReportContainer key={report.id}>
+          <ReportContainer key={report.id} id={`trip-report-${report.date}`}>
             <ReportHeader>
               <SemiBold>
                 {'On '}
@@ -329,7 +329,7 @@ const TripReports = ({mountainId, mountainName}: Props) => {
     output = null;
   }
   return (
-    <VerticalContentItem>
+    <VerticalContentItem id={'trip-reports'}>
       <ItemTitle>
         {getFluentString('trip-reports-title')}
       </ItemTitle>

--- a/client/src/components/mountains/list/index.tsx
+++ b/client/src/components/mountains/list/index.tsx
@@ -9,6 +9,7 @@ import {
   AppLocalizationAndBundleContext,
 } from '../../../contextProviders/getFluentLocalizationContext';
 import { searchMountainsDetailLink } from '../../../routing/Utils';
+import { Routes } from '../../../routing/routes';
 import {
   ContentBody,
   ContentLeftSmall,
@@ -20,6 +21,7 @@ import {
   PaginationContainer,
   PlaceholderText,
   Prev,
+  FloatingButton,
 } from '../../../styling/styleUtils';
 import { State } from '../../../types/graphQLTypes';
 import {
@@ -33,6 +35,16 @@ import MountainDetail from '../detail/MountainDetail';
 import GhostMountainCard from './GhostMountainCard';
 import ListMountains, { MountainDatum } from './ListMountains';
 import LocationFilter from './LocationFilter';
+import styled from 'styled-components';
+
+const PlusIcon = styled.span`
+  font-size: 1.3rem;
+  height: 0;
+  display: inline-block;
+  line-height: 0;
+  position: relative;
+  top: 2px;
+`;
 
 const SEARCH_MOUNTAINS = gql`
   query SearchMountains(
@@ -219,6 +231,9 @@ const MountainSearchPage = (props: Props) => {
         </SearchContainer>
         <ContentBody ref={listContainerElm}>
           {list}
+          <FloatingButton to={Routes.CreateMountain}>
+            <PlusIcon>+</PlusIcon> Add Mountain
+          </FloatingButton>
         </ContentBody>
       </ContentLeftSmall>
       <ContentRightLarge>

--- a/client/src/components/mountains/list/index.tsx
+++ b/client/src/components/mountains/list/index.tsx
@@ -83,10 +83,11 @@ interface Variables {
 
 interface Props extends RouteComponentProps {
   userId: string | null;
+  mountainPermissions: number | null;
 }
 
 const MountainSearchPage = (props: Props) => {
-  const { userId, match, location, history } = props;
+  const { userId, mountainPermissions, match, location, history } = props;
   const { id }: any = match.params;
   const { query, page } = queryString.parse(location.search);
 
@@ -207,7 +208,7 @@ const MountainSearchPage = (props: Props) => {
       )
     : ( <MountainDetail userId={userId} id={id} />);
 
-  const addMountainButton = userId ? (
+  const addMountainButton = userId && mountainPermissions !== -1 ? (
     <FloatingButton to={Routes.CreateMountain}>
       <PlusIcon>+</PlusIcon> {getFluentString('create-mountain-title-create')}
     </FloatingButton>

--- a/client/src/components/mountains/list/index.tsx
+++ b/client/src/components/mountains/list/index.tsx
@@ -5,11 +5,12 @@ import { Types } from 'mongoose';
 import queryString from 'query-string';
 import React, { useContext, useEffect, useRef, useState } from 'react';
 import { RouteComponentProps, withRouter } from 'react-router';
+import styled from 'styled-components';
 import {
   AppLocalizationAndBundleContext,
 } from '../../../contextProviders/getFluentLocalizationContext';
-import { searchMountainsDetailLink } from '../../../routing/Utils';
 import { Routes } from '../../../routing/routes';
+import { searchMountainsDetailLink } from '../../../routing/Utils';
 import {
   ContentBody,
   ContentLeftSmall,
@@ -17,11 +18,11 @@ import {
   SearchContainer,
 } from '../../../styling/Grid';
 import {
+  FloatingButton,
   Next,
   PaginationContainer,
   PlaceholderText,
   Prev,
-  FloatingButton,
 } from '../../../styling/styleUtils';
 import { State } from '../../../types/graphQLTypes';
 import {
@@ -35,7 +36,6 @@ import MountainDetail from '../detail/MountainDetail';
 import GhostMountainCard from './GhostMountainCard';
 import ListMountains, { MountainDatum } from './ListMountains';
 import LocationFilter from './LocationFilter';
-import styled from 'styled-components';
 
 const PlusIcon = styled.span`
   font-size: 1.3rem;
@@ -207,6 +207,12 @@ const MountainSearchPage = (props: Props) => {
       )
     : ( <MountainDetail userId={userId} id={id} />);
 
+  const addMountainButton = userId ? (
+    <FloatingButton to={Routes.CreateMountain}>
+      <PlusIcon>+</PlusIcon> {getFluentString('create-mountain-title-create')}
+    </FloatingButton>
+  ) : null;
+
   return (
     <>
       <ContentLeftSmall>
@@ -231,9 +237,7 @@ const MountainSearchPage = (props: Props) => {
         </SearchContainer>
         <ContentBody ref={listContainerElm}>
           {list}
-          <FloatingButton to={Routes.CreateMountain}>
-            <PlusIcon>+</PlusIcon> Add Mountain
-          </FloatingButton>
+          {addMountainButton}
         </ContentBody>
       </ContentLeftSmall>
       <ContentRightLarge>

--- a/client/src/components/peakLists/detail/completionModal/MountainCompletionModal.tsx
+++ b/client/src/components/peakLists/detail/completionModal/MountainCompletionModal.tsx
@@ -1392,6 +1392,11 @@ const MountainCompletionModal = (props: PropsWithConditions) => {
       </DeleteButton>
     ) : null;
 
+  const saveButtonText = 
+    tripReportId !== undefined || initialStartDate !== null || initialDateType !== DateType.full
+      ? getFluentString('global-text-value-save')
+      : getFluentString('global-text-value-modal-mark-complete');
+
   const actions = (
     <ButtonWrapper>
       {deleteAscentButton}
@@ -1402,7 +1407,7 @@ const MountainCompletionModal = (props: PropsWithConditions) => {
         onClick={() => validateAndAddMountainCompletion(editMountainId)}
         disabled={isConfirmDisabled()}
       >
-        {getFluentString('global-text-value-modal-mark-complete')}
+        {saveButtonText}
       </ButtonPrimary>
     </ButtonWrapper>
   );

--- a/client/src/components/peakLists/detail/completionModal/MountainCompletionModal.tsx
+++ b/client/src/components/peakLists/detail/completionModal/MountainCompletionModal.tsx
@@ -1392,7 +1392,7 @@ const MountainCompletionModal = (props: PropsWithConditions) => {
       </DeleteButton>
     ) : null;
 
-  const saveButtonText = 
+  const saveButtonText =
     tripReportId !== undefined || initialStartDate !== null || initialDateType !== DateType.full
       ? getFluentString('global-text-value-save')
       : getFluentString('global-text-value-modal-mark-complete');

--- a/client/src/components/sharedComponents/AreYouSureModal.tsx
+++ b/client/src/components/sharedComponents/AreYouSureModal.tsx
@@ -6,16 +6,16 @@ import {
 } from '../../styling/styleUtils';
 import Modal from './Modal';
 
-const ButtonWrapper = styled.div`
+export const ButtonWrapper = styled.div`
   display: flex;
   justify-content: flex-end;
 `;
 
-const CancelButton = styled(ButtonSecondary)`
+export const CancelButton = styled(ButtonSecondary)`
   margin-right: 1rem;
 `;
 
-interface Props {
+export interface Props {
   onConfirm: () => void;
   onCancel: () => void;
   title: string;

--- a/client/src/components/sharedComponents/map/index.tsx
+++ b/client/src/components/sharedComponents/map/index.tsx
@@ -195,11 +195,14 @@ interface Props {
   highlighted?: CoordinateWithDates[];
   peakListType: PeakListVariants;
   isOtherUser?: boolean;
-  hideLegend?: boolean;
+  createOrEditMountain?: boolean;
 }
 
 const Map = (props: Props) => {
-  const { id, coordinates, highlighted, peakListType, userId, isOtherUser } = props;
+  const {
+    id, coordinates, highlighted, peakListType,
+    userId, isOtherUser, createOrEditMountain
+  } = props;
 
   const {localization} = useContext(AppLocalizationAndBundleContext);
   const getFluentString: GetString = (...args) => localization.getString(...args);
@@ -253,9 +256,11 @@ const Map = (props: Props) => {
   }, [map]);
 
   useEffect(() => {
-    const coords = getMinMax(coordinates);
-    setFitBounds([[coords.minLong, coords.minLat], [coords.maxLong, coords.maxLat]]);
-  }, [coordinates]);
+    if (!createOrEditMountain) {
+      const coords = getMinMax(coordinates);
+      setFitBounds([[coords.minLong, coords.minLat], [coords.maxLong, coords.maxLat]]);
+    }
+  }, [coordinates, createOrEditMountain]);
 
   useEffect(() => {
     if (highlighted && highlighted.length === 1) {
@@ -279,7 +284,12 @@ const Map = (props: Props) => {
     };
     let circleColor: string;
     if (completionDates === null) {
-      circleColor = twoColorScale[0];
+      if (createOrEditMountain === true && highlighted && highlighted.length &&
+        (point.latitude === highlighted[0].latitude && point.longitude === highlighted[0].longitude)) {
+        circleColor = twoColorScale[1];
+      } else {
+        circleColor = twoColorScale[0];
+      }
     } else if (completionDates.type === PeakListVariants.standard) {
       circleColor = completionDates.standard !== undefined ? twoColorScale[1] : twoColorScale[0];
     } else if (completionDates.type === PeakListVariants.winter) {
@@ -454,8 +464,19 @@ const Map = (props: Props) => {
   );
 
   let colorScaleLegend: React.ReactElement<any> | null;
-  if (props.hideLegend === true) {
-    colorScaleLegend = null;
+  if (createOrEditMountain === true) {
+    colorScaleLegend = (
+      <ColorScaleLegend>
+        <LegendItem>
+          <Circle style={{backgroundColor: twoColorScale[0]}} />
+          {getFluentString('create-mountain-map-nearby-mountains')}
+        </LegendItem>
+        <LegendItem>
+          <Circle style={{backgroundColor: twoColorScale[1]}} />
+          {getFluentString('create-mountain-map-your-mountain')}
+        </LegendItem>
+      </ColorScaleLegend>
+    );
   } else if (peakListType === PeakListVariants.standard || peakListType === PeakListVariants.winter) {
     colorScaleLegend = (
       <ColorScaleLegend>

--- a/client/src/components/sharedComponents/map/index.tsx
+++ b/client/src/components/sharedComponents/map/index.tsx
@@ -13,12 +13,13 @@ import ReactMapboxGl, {
   RotationControl,
   ZoomControl,
 } from 'react-mapbox-gl';
-import styled from 'styled-components/macro';
+import styled from 'styled-components';
 import {
   AppLocalizationAndBundleContext,
 } from '../../../contextProviders/getFluentLocalizationContext';
 import { listDetailWithMountainDetailLink, mountainDetailLink } from '../../../routing/Utils';
 import {
+  ButtonPrimary,
   lightBorderColor,
   linkStyles,
   placeholderColor,
@@ -166,6 +167,62 @@ const AddAscentButton = styled.button`
   background-color: transparent;
 `;
 
+const CenterCoordinatesContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-right: auto;
+  margin-left: 1rem;
+`;
+
+const CenterCoordinatesTitle = styled.div`
+  font-size: 0.9rem;
+  font-weight: 600;
+`;
+
+const CenterCoordinatesSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  text-transform: uppercase;
+  font-size: 0.8rem;
+`;
+
+const Crosshair = styled.div`
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 50%;
+    height: 100%;
+    border-right: 1px solid gray;
+  }
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 50%;
+    border-bottom: 1px solid gray;
+  }
+`;
+
+const ActionButton = styled(ButtonPrimary)`
+  margin-top: 0.5rem;
+  font-size: 0.7rem;
+  padding: 0.2rem 0.3rem;
+`;
+
 const getMinMax = (coordinates: Coordinate[]) => {
   const sortedByLat = sortBy(coordinates, ['latitude']);
   const sortedByLong = sortBy(coordinates, ['longitude']);
@@ -196,12 +253,15 @@ interface Props {
   peakListType: PeakListVariants;
   isOtherUser?: boolean;
   createOrEditMountain?: boolean;
+  showCenterCrosshairs?: boolean;
+  returnLatLongOnClick?: (lat: number | string, lng: number | string) => void;
 }
 
 const Map = (props: Props) => {
   const {
     id, coordinates, highlighted, peakListType,
-    userId, isOtherUser, createOrEditMountain
+    userId, isOtherUser, createOrEditMountain,
+    showCenterCrosshairs, returnLatLongOnClick,
   } = props;
 
   const {localization} = useContext(AppLocalizationAndBundleContext);
@@ -228,6 +288,9 @@ const Map = (props: Props) => {
     useState<[[number, number], [number, number]] | undefined>([[minLong, minLat], [maxLong, maxLat]]);
   const [map, setMap] = useState<any>(null);
 
+  const latLngDecimalPoints = 8;
+  const [centerCoords, setCenterCoords] = useState<[string, string]>(
+    [initialCenter[0].toFixed(latLngDecimalPoints), initialCenter[1].toFixed(latLngDecimalPoints)]);
   useEffect(() => {
     const enableZoom = (e: KeyboardEvent) => {
       if (e.shiftKey && map) {
@@ -248,12 +311,25 @@ const Map = (props: Props) => {
     document.body.addEventListener('keyup', disableZoom);
     document.body.addEventListener('touchstart', disableDragPanOnTouchDevics);
 
+    const getCenterCoords = () => {
+      if (map) {
+        const {lat, lng}: {lat: number, lng: number} = map.getCenter();
+        setCenterCoords([lat.toFixed(latLngDecimalPoints), lng.toFixed(latLngDecimalPoints)]);
+      }
+    };
+    if (map && showCenterCrosshairs) {
+      map.on('move', getCenterCoords);
+    }
+
     return () => {
       document.body.removeEventListener('keydown', enableZoom);
       document.body.removeEventListener('keyup', disableZoom);
       document.body.removeEventListener('touchstart', disableDragPanOnTouchDevics);
+      if (map && showCenterCrosshairs) {
+        map.off('move', getCenterCoords);
+      }
     };
-  }, [map]);
+  }, [map, showCenterCrosshairs]);
 
   useEffect(() => {
     if (!createOrEditMountain) {
@@ -465,8 +541,29 @@ const Map = (props: Props) => {
 
   let colorScaleLegend: React.ReactElement<any> | null;
   if (createOrEditMountain === true) {
+    let latLongLegend: React.ReactElement<any> | null;
+    if (showCenterCrosshairs === true) {
+      const returnLatLongButton = returnLatLongOnClick === undefined ? null : (
+        <ActionButton onClick={() => returnLatLongOnClick(...centerCoords)}>
+          {getFluentString('map-set-lat-long-value')}
+        </ActionButton>
+      );
+      latLongLegend = (
+        <CenterCoordinatesContainer>
+          <CenterCoordinatesTitle>{getFluentString('map-coordinates-at-center')}</CenterCoordinatesTitle>
+          <CenterCoordinatesSection>
+            <span>{getFluentString('global-text-value-latitude')}: {centerCoords[0]}</span>
+            <span>{getFluentString('global-text-value-longitude')}: {centerCoords[1]}</span>
+            {returnLatLongButton}
+          </CenterCoordinatesSection>
+        </CenterCoordinatesContainer>
+      );
+    } else {
+      latLongLegend = null;
+    }
     colorScaleLegend = (
       <ColorScaleLegend>
+        {latLongLegend}
         <LegendItem>
           <Circle style={{backgroundColor: twoColorScale[0]}} />
           {getFluentString('create-mountain-map-nearby-mountains')}
@@ -544,6 +641,8 @@ const Map = (props: Props) => {
     return null;
   };
 
+  const crosshairs = showCenterCrosshairs === true ? <Crosshair /> : <React.Fragment />;
+
   return (
     <Root
       style={{pointerEvents: !map ? 'none' : undefined}}
@@ -580,6 +679,7 @@ const Map = (props: Props) => {
           {features}
         </Layer>
         {popup}
+        {crosshairs}
         <MapContext.Consumer children={mapRenderProps} />
       </Mapbox>
       {colorScaleLegend}

--- a/client/src/components/sharedComponents/map/index.tsx
+++ b/client/src/components/sharedComponents/map/index.tsx
@@ -186,7 +186,7 @@ interface Coordinate {
   elevation: number;
 }
 
-type CoordinateWithDates = Coordinate & {completionDates: VariableDate | null};
+export type CoordinateWithDates = Coordinate & {completionDates: VariableDate | null};
 
 interface Props {
   id: string;
@@ -195,6 +195,7 @@ interface Props {
   highlighted?: CoordinateWithDates[];
   peakListType: PeakListVariants;
   isOtherUser?: boolean;
+  hideLegend?: boolean;
 }
 
 const Map = (props: Props) => {
@@ -453,7 +454,9 @@ const Map = (props: Props) => {
   );
 
   let colorScaleLegend: React.ReactElement<any> | null;
-  if (peakListType === PeakListVariants.standard || peakListType === PeakListVariants.winter) {
+  if (props.hideLegend === true) {
+    colorScaleLegend = null;
+  } else if (peakListType === PeakListVariants.standard || peakListType === PeakListVariants.winter) {
     colorScaleLegend = (
       <ColorScaleLegend>
         <LegendItem>

--- a/client/src/contextProviders/messages.ftl
+++ b/client/src/contextProviders/messages.ftl
@@ -362,6 +362,9 @@ trip-report-no-reports = There are no recent trips reports for { $mountain-name 
 trip-reports-load-more-button = Load More Reports
 trip-reports-view-edit-button = View/Edit Report
 
+create-mountain-title-create = Add Mountain
+create-mountain-title-edit = Edit Mountain: { $mountain-name }
+
 create-mountain-map-your-mountain = Your Mountain
 create-mountain-map-nearby-mountains = Nearby Mountains
 create-mountain-mountain-name-placeholder = Mountain Name

--- a/client/src/contextProviders/messages.ftl
+++ b/client/src/contextProviders/messages.ftl
@@ -27,6 +27,7 @@ global-text-value-loading-extra-long =  Hmmm, I don't know how we got here. Cont
 
 global-error-retrieving-data = There was an error retrieving the data. Please try refreshing or accessing a different page. If the problem persists, contact us at wilderlistapp@gmail.com
 global-error-saving-data = There was a network error trying to save the data. Please try again. If the problem persists, contact us at wilderlistapp@gmail.com
+global-text-value-no-permission = You do not have permission to access this page. If you think this is in error, please contact us at wilderlistapp@gmail.com
 
 global-text-value-modal-reddit = Reddit
 global-text-value-modal-email = Email

--- a/client/src/contextProviders/messages.ftl
+++ b/client/src/contextProviders/messages.ftl
@@ -361,3 +361,13 @@ trip-report-hiked-with = Hiked With
 trip-report-no-reports = There are no recent trips reports for { $mountain-name }
 trip-reports-load-more-button = Load More Reports
 trip-reports-view-edit-button = View/Edit Report
+
+create-mountain-map-your-mountain = Your Mountain
+create-mountain-map-nearby-mountains = Nearby Mountains
+create-mountain-mountain-name-placeholder = Mountain Name
+create-mountain-select-a-state = Select a State
+create-mountain-latitude-placeholder = Enter the latitude in decimal format
+create-mountain-longitude-placeholder = Enter the longitude in decimal format
+create-mountain-elevation-placeholder = Enter the elevation in feet
+
+create-mountain-check-your-work = Check the map to make sure your information is accurate. Double-check nearby mountains (highlighted in red) to make sure you are not adding a duplicate. Duplicates will be deleted.

--- a/client/src/contextProviders/messages.ftl
+++ b/client/src/contextProviders/messages.ftl
@@ -14,6 +14,7 @@ global-text-value-no-users-found-for-term = No users found for&#32;<strong>{ $te
 global-text-value-are-you-sure-modal = Please Confirm
 global-text-value-modal-confirm = Confirm
 global-text-value-modal-cancel = Cancel
+global-text-value-cancel-delete-request = Cancel delete request
 global-text-value-modal-close = Close
 global-text-value-modal-mark-complete = Mark Complete
 global-text-value-more = more
@@ -37,6 +38,9 @@ global-text-value-modal-sign-up-today-import = Import your data for { $list-shor
 global-text-value-modal-sign-up-today-export = Export your data for { $list-short-name } with a free account
 global-text-value-modal-sign-up-today-ascents-list = Start tracking ascents for { $mountain-name } and other peaks with a free account
 
+global-text-value-modal-cancel-request-text = This will cancel your request to have { $name } deleted.
+global-text-value-modal-request-delete-title = Request delete
+global-text-value-modal-request-delete-text = This will submit a request to have { $name } deleted. Are you sure you want to continue?
 
 global-text-value-mountain = Mountain
 global-text-value-mountains = Mountains
@@ -87,6 +91,8 @@ global-text-value-submit = Submit
 global-text-value-edit = Edit
 global-text-value-save = Save
 global-text-value-saving = Saving
+
+global-text-value-delete = Delete
 
 global-text-value-flag = Flag
 
@@ -383,3 +389,20 @@ create-mountain-longitude-placeholder = Enter the longitude in decimal format
 create-mountain-elevation-placeholder = Enter the elevation in feet
 
 create-mountain-check-your-work = I have checked the map to make sure my information is accurate. I have double-checked nearby mountains (highlighted in red) to make sure I am not adding a duplicate (duplicates will be removed). I understand that repeated inaccurate or duplicate submissions could result in my losing the ability to post new mountains.
+
+flag-mountain-title = Submit a Flag for { $name }
+flag-mountain-text = If something seems wrong about this mountain, submit a flag and an administrator will take a look at it ASAP
+flag-mountain-thanks = Thank you for submitting your flag. An administrator will be looking into it shortly.
+
+flag-mountain-select-issue = Please select an issue from the box below
+flag-mountain-select-issue-description = {
+  $issue ->
+    [location] Location - The location (latitude/longitude) is incorrect
+    [elevation] Elevation - The elevation is wrong
+    [state] State - The listed State is wrong
+    [duplicate] Duplicate - This is a duplicate entry of the mountain
+    [data] Data - There is an issue with data (i.e. name, trails, reports)
+    [abuse] Abuse - This entry is inappropriate or otherwise abusive
+    *[other] Other - There is a problem not specified in this list
+}
+

--- a/client/src/contextProviders/messages.ftl
+++ b/client/src/contextProviders/messages.ftl
@@ -25,6 +25,7 @@ global-text-value-loading-long =  Our bearing seems to be off, sorry about the w
 global-text-value-loading-extra-long =  Hmmm, I don't know how we got here. Contact us at wilderlistapp@gmail.com if these loading times continue
 
 global-error-retrieving-data = There was an error retrieving the data. Please try refreshing or accessing a different page. If the problem persists, contact us at wilderlistapp@gmail.com
+global-error-saving-data = There was a network error trying to save the data. Please try again. If the problem persists, contact us at wilderlistapp@gmail.com
 
 global-text-value-modal-reddit = Reddit
 global-text-value-modal-email = Email
@@ -43,6 +44,7 @@ global-text-value-dates = Dates
 global-text-value-regions = Regions
 global-text-value-state = State
 global-text-value-elevation = Elevation
+global-text-value-feet = feet
 global-text-value-latitude = Latitude
 global-text-value-longitude = Longitude
 global-text-value-prominence = Prominence
@@ -84,6 +86,7 @@ global-text-value-submit = Submit
 
 global-text-value-edit = Edit
 global-text-value-save = Save
+global-text-value-saving = Saving
 
 header-text-login-with-google = Sign in With Google
 header-text-login-with-reddit = Sign in With Reddit
@@ -250,6 +253,9 @@ map-all-seasons = All Seasons
 map-no-months = No Months
 map-all-months = All Months
 
+map-coordinates-at-center = Coordinates at Center
+map-set-lat-long-value = Set Lat/Long to these values
+
 import-ascents-title = Import Ascents
 import-ascents-para-1 = This tool will import your existing ascent data from a spreadsheet and into Wilderlist.
 import-ascents-date-note = <strong>Note:</strong>&#32;Dates must be in&#32;<strong>Month/Day/Year</strong>&#32;format in order to be properly read.
@@ -369,8 +375,9 @@ create-mountain-map-your-mountain = Your Mountain
 create-mountain-map-nearby-mountains = Nearby Mountains
 create-mountain-mountain-name-placeholder = Mountain Name
 create-mountain-select-a-state = Select a State
+create-mountain-latlong-note = as a decimal
 create-mountain-latitude-placeholder = Enter the latitude in decimal format
 create-mountain-longitude-placeholder = Enter the longitude in decimal format
 create-mountain-elevation-placeholder = Enter the elevation in feet
 
-create-mountain-check-your-work = Check the map to make sure your information is accurate. Double-check nearby mountains (highlighted in red) to make sure you are not adding a duplicate. Duplicates will be deleted.
+create-mountain-check-your-work = I have checked the map to make sure my information is accurate. I have double-checked nearby mountains (highlighted in red) to make sure I am not adding a duplicate (duplicates will be removed). I understand that repeated inaccurate or duplicate submissions could result in my losing the ability to post new mountains.

--- a/client/src/contextProviders/messages.ftl
+++ b/client/src/contextProviders/messages.ftl
@@ -88,6 +88,8 @@ global-text-value-edit = Edit
 global-text-value-save = Save
 global-text-value-saving = Saving
 
+global-text-value-flag = Flag
+
 header-text-login-with-google = Sign in With Google
 header-text-login-with-reddit = Sign in With Reddit
 header-text-menu-item-dashboard = Dashboard

--- a/client/src/routing/Utils.ts
+++ b/client/src/routing/Utils.ts
@@ -30,6 +30,7 @@ export const listDetailWithMountainDetailLink = ((peakListId: string, mountainId
 });
 
 export const searchMountainsDetailLink = ((id: string) => Routes.MountainSearchWithDetail.replace(':id', id));
+export const editMountainLink = ((id: string) => Routes.EditMountain.replace(':id', id));
 
 export const preventNavigation = (e: React.SyntheticEvent) => {
   e.preventDefault();

--- a/client/src/routing/routes.ts
+++ b/client/src/routing/routes.ts
@@ -7,6 +7,7 @@ export enum Routes {
   ListDetailWithMountainDetail = '/list/:id/mountain/:mountainId',
   MountainSearchWithDetail = '/mountains/:id',
   MountainDetail = '/mountain/:id',
+  CreateMountain = '/create-mountain',
   FriendsWithProfile = '/users/:id',
   UserProfile = '/user/:id',
   UserSettings = '/user-settings',

--- a/client/src/routing/routes.ts
+++ b/client/src/routing/routes.ts
@@ -8,6 +8,7 @@ export enum Routes {
   MountainSearchWithDetail = '/mountains/:id',
   MountainDetail = '/mountain/:id',
   CreateMountain = '/create-mountain',
+  EditMountain = '/edit-mountain/:id',
   FriendsWithProfile = '/users/:id',
   UserProfile = '/user/:id',
   UserSettings = '/user-settings',

--- a/client/src/setupProxy.js
+++ b/client/src/setupProxy.js
@@ -1,5 +1,5 @@
 const proxy = require('http-proxy-middleware')
 
 module.exports = function(app) {
-    app.use(proxy(['/api', '/auth/google', '/auth/reddit', '/graphql', '/api/ascent-invite'], { target: 'http://localhost:5050' }));
+    app.use(proxy(['/api', '/auth/google', '/auth/reddit', '/graphql', '/api/ascent-invite', '/api/send-email'], { target: 'http://localhost:5050' }));
 }

--- a/client/src/styling/styleUtils.ts
+++ b/client/src/styling/styleUtils.ts
@@ -1,8 +1,8 @@
+import { darken } from 'polished';
 import styled from 'styled-components/macro';
 import DynamicLink from '../components/sharedComponents/DynamicLink';
 import { PeakListVariants } from '../types/graphQLTypes';
 import { failIfValidOrNonExhaustive } from '../Utils';
-import { darken } from 'polished';
 
 export const baseColor = '#333333'; // dark gray/black color for text
 export const lightBaseColor = '#7c7c7c'; // light gray color for subtitles and contextual information
@@ -305,6 +305,29 @@ export const NoResults = styled.div`
   font-style: italic;
   color: ${placeholderColor};
   text-align: center;
+`;
+
+export const CheckboxRoot = styled.div`
+  display: block;
+  position: relative;
+`;
+
+export const CheckboxInput = styled.input`
+  position: absolute;
+  left: 4px;
+  top: 0;
+  bottom: 0;
+  margin: auto;
+`;
+
+export const CheckboxLabel = styled.label`
+  padding: 8px 8px 8px 30px;
+  display: block;
+
+  &:hover {
+    background-color: #eee;
+    cursor: pointer;
+  }
 `;
 
 /* tslint:disable:max-line-length */

--- a/client/src/styling/styleUtils.ts
+++ b/client/src/styling/styleUtils.ts
@@ -2,6 +2,7 @@ import styled from 'styled-components/macro';
 import DynamicLink from '../components/sharedComponents/DynamicLink';
 import { PeakListVariants } from '../types/graphQLTypes';
 import { failIfValidOrNonExhaustive } from '../Utils';
+import { darken } from 'polished';
 
 export const baseColor = '#333333'; // dark gray/black color for text
 export const lightBaseColor = '#7c7c7c'; // light gray color for subtitles and contextual information
@@ -227,6 +228,17 @@ export const GhostButton = styled(ButtonBase)`
   }
 `;
 
+export const FloatingButton = styled(ButtonPrimaryLink)`
+  position: sticky;
+  bottom: 0;
+  left: 100%;
+  font-size: 0.75rem;
+  border-radius: 15px;
+  border-bottom: 3px solid ${darken(0.12, primaryColor)};
+  border-right: 3px solid ${darken(0.12, primaryColor)};
+  box-shadow: 0px 0px 3px -1px #b5b5b5;
+`;
+
 export const InputBase = styled.input`
   padding: 8px;
   box-sizing: border-box;
@@ -249,6 +261,7 @@ export const Label = styled.span`
 
 export const PaginationContainer = styled.div`
   display: flex;
+  margin-bottom: 2rem;
 `;
 
 export const Next = styled(ButtonSecondary)`

--- a/client/src/styling/styleUtils.ts
+++ b/client/src/styling/styleUtils.ts
@@ -219,6 +219,23 @@ export const ButtonPrimaryLink = styled(DynamicLink)`
     background-color: ${primaryHoverColor};
   }
 `;
+export const ButtonSecondaryLink = styled(DynamicLink)`
+  padding: 0.6rem;
+  text-transform: uppercase;
+  color: #fff;
+  text-align: center;
+  border-radius: ${borderRadius}px;
+  font-weight: ${semiBoldFontBoldWeight};
+  font-size: 0.8rem;
+  background-color: ${secondaryColor};
+  display: inline-block;
+  text-decoration: none;
+
+  &:hover {
+    color: #fff;
+    background-color: ${secondaryHoverColor};
+  }
+`;
 
 export const GhostButton = styled(ButtonBase)`
   color: ${secondaryColor};

--- a/client/src/styling/styleUtils.ts
+++ b/client/src/styling/styleUtils.ts
@@ -22,6 +22,7 @@ export const warningColor = '#b9161a'; // bright red for warning buttons
 export const warningHoverColor = '#db363a'; // bright red for warning buttons
 export const lowWarningColorLight = '#f2e4b3';
 export const lowWarningColor = '#d6aa0a';
+export const lowWarningColorDark = '#8a7e54';
 
 export const successColor = '#658238';
 export const successColorLight = '#d0e3b1';

--- a/client/src/styling/styleUtils.ts
+++ b/client/src/styling/styleUtils.ts
@@ -306,3 +306,26 @@ export const NoResults = styled.div`
   color: ${placeholderColor};
   text-align: center;
 `;
+
+/* tslint:disable:max-line-length */
+export const SelectBox = styled.select`
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  font-size: 1rem;
+  padding: 8px;
+  border: solid 1px ${lightBorderColor};
+  border-radius: 0;
+  background-color: white;
+  background-image: url('data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%23666666%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.5-3.5%205.4-7.8%205.4-12.8%200-5-1.9-9.2-5.5-12.8z%22%2F%3E%3C%2Fsvg%3E'),
+    linear-gradient(to bottom, #ffffff 0%,#ffffff 100%);
+  background-repeat: no-repeat, repeat;
+  background-position: right .7em top 50%, 0 0;
+  background-size: .65em auto, 100%;
+  display: block;
+  width: 100%;
+
+  &:hover {
+    cursor: pointer;
+    background-color: white;
+  }
+`;

--- a/client/src/types/graphQLTypes.ts
+++ b/client/src/types/graphQLTypes.ts
@@ -21,10 +21,13 @@ export enum CreatedItemStatus {
 
 export enum MountainFlag {
   location = 'location',
+  elevation = 'elevation',
+  state = 'state',
   duplicate = 'duplicate',
   data = 'data',
   abuse = 'abuse',
   other = 'other',
+  deleteRequest = 'deleteRequest',
 }
 
 export interface Mountain {

--- a/client/src/types/graphQLTypes.ts
+++ b/client/src/types/graphQLTypes.ts
@@ -13,6 +13,20 @@ export interface State {
   peakLists: Array<PeakList | null> | null;
 }
 
+export enum CreatedItemStatus {
+  pending = 'pending',
+  auto = 'auto',
+  accepted = 'accepted',
+}
+
+export enum MountainFlag {
+  location = 'location',
+  duplicate = 'duplicate',
+  data = 'data',
+  abuse = 'abuse',
+  other = 'other',
+}
+
 export interface Mountain {
   id: string;
   name: string;
@@ -22,6 +36,10 @@ export interface Mountain {
   elevation: number;
   prominence: number | null;
   lists: Array<PeakList | null>;
+  author: User | null;
+  status: CreatedItemStatus | null;
+  flag: MountainFlag | null;
+
 }
 
 export enum PeakListVariants {
@@ -106,6 +124,7 @@ export interface User {
   peakListNote: PeakListNote | null;
   mountainNotes: Array<MountainNote | null> | null;
   mountainNote: MountainNote | null;
+  mountainPermissions: number | null;
 }
 
 export interface Conditions {

--- a/client/src/utilities/sendGenericEmail.ts
+++ b/client/src/utilities/sendGenericEmail.ts
@@ -1,0 +1,30 @@
+import axios from 'axios';
+
+interface Params {
+  emailList: string[];
+  subject: string;
+  title: string;
+  content: string;
+  ctaText: string;
+  ctaLink: string;
+}
+
+const sendGenericEmail = (input: Params) => {
+  const {
+    emailList, subject, title,
+    content, ctaText, ctaLink,
+  } = input;
+  emailList.forEach((email) => {
+    axios.get('/api/send-email', {
+      params: {
+        userEmail: email, subject, title,
+        content, ctaText, ctaLink,
+      },
+    })
+    .catch(function(error) {
+      console.error(error);
+    });
+  });
+};
+
+export default sendGenericEmail;

--- a/package-lock.json
+++ b/package-lock.json
@@ -555,9 +555,9 @@
       }
     },
     "@types/bson": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.0.tgz",
-      "integrity": "sha512-pq/rqJwJWkbS10crsG5bgnrisL8pML79KlMKQMoQwLUjlPAkrUHMvHJ3oGwE7WHR61Lv/nadMwXVAD2b+fpD8Q==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.1.tgz",
+      "integrity": "sha512-K6VAEdLVJFBxKp8m5cRTbUfeZpuSvOuLKJLrgw9ANIXo00RiyGzgH4BKWWR4F520gV4tWmxG7q9sKQRVDuzrBw==",
       "requires": {
         "@types/node": "*"
       }
@@ -689,18 +689,18 @@
       "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw=="
     },
     "@types/mongodb": {
-      "version": "3.1.28",
-      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.1.28.tgz",
-      "integrity": "sha512-tG+QqJ/hir2p0069ee28t2O9tlGRJKDq1WFZC2QYMlU47LGdldLL8tepfTq6aFLvP58OpwSoxaJ/qjW93ob1NQ==",
+      "version": "3.3.14",
+      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.3.14.tgz",
+      "integrity": "sha512-Ie0Fjoifm/TPY2rNOgixzhNSjDgxgR0dMKQk9XqUXHnkfuw26SpbMXjwECfxSnEdG1bH6bIlpLIK7HvGHQhzqg==",
       "requires": {
         "@types/bson": "*",
         "@types/node": "*"
       }
     },
     "@types/mongoose": {
-      "version": "5.5.8",
-      "resolved": "https://registry.npmjs.org/@types/mongoose/-/mongoose-5.5.8.tgz",
-      "integrity": "sha512-PtKUS5IC72F/5dwaUaCleYlXuaXXLDUL2wUGSnteq7ifUDQRqNji/vEpK8KQR+uHiRih1l90g4doOAZOc9veUg==",
+      "version": "5.5.41",
+      "resolved": "https://registry.npmjs.org/@types/mongoose/-/mongoose-5.5.41.tgz",
+      "integrity": "sha512-Hg8amaVUUUk7iB0TXJ2Ki1Agb4IuJag5R6U5i1H+b+1wclf93NLOEPemmbd4Bc9ZqOtVUmjPIc00SwCqEHTbVQ==",
       "requires": {
         "@types/mongodb": "*",
         "@types/node": "*"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@types/express-graphql": "^0.8.0",
     "@types/graphql": "^14.2.2",
     "@types/lodash": "^4.14.136",
-    "@types/mongoose": "^5.5.8",
+    "@types/mongoose": "^5.5.41",
     "@types/nodemailer": "^6.2.2",
     "@types/passport": "^1.0.0",
     "@types/passport-google-oauth20": "^2.0.2",

--- a/src/server/graphql/graphQLTypes.ts
+++ b/src/server/graphql/graphQLTypes.ts
@@ -21,10 +21,13 @@ export enum CreatedItemStatus {
 
 export enum MountainFlag {
   location = 'location',
+  elevation = 'elevation',
+  state = 'state',
   duplicate = 'duplicate',
   data = 'data',
   abuse = 'abuse',
   other = 'other',
+  deleteRequest = 'deleteRequest',
 }
 
 export interface Mountain {

--- a/src/server/graphql/graphQLTypes.ts
+++ b/src/server/graphql/graphQLTypes.ts
@@ -13,6 +13,20 @@ export interface State {
   peakLists: Array<PeakList | null> | null;
 }
 
+export enum CreatedItemStatus {
+  pending = 'pending',
+  auto = 'auto',
+  accepted = 'accepted',
+}
+
+export enum MountainFlag {
+  location = 'location',
+  duplicate = 'duplicate',
+  data = 'data',
+  abuse = 'abuse',
+  other = 'other',
+}
+
 export interface Mountain {
   id: string;
   name: string;
@@ -22,6 +36,10 @@ export interface Mountain {
   elevation: number;
   prominence: number | null;
   lists: Array<PeakList | null>;
+  author: User | null;
+  status: CreatedItemStatus | null;
+  flag: MountainFlag | null;
+
 }
 
 export enum PeakListVariants {
@@ -106,6 +124,7 @@ export interface User {
   peakListNote: PeakListNote | null;
   mountainNotes: Array<MountainNote | null> | null;
   mountainNote: MountainNote | null;
+  mountainPermissions: number | null;
 }
 
 export interface Conditions {

--- a/src/server/graphql/schema/mutations/mountainMutations.ts
+++ b/src/server/graphql/schema/mutations/mountainMutations.ts
@@ -48,6 +48,9 @@ const mountainMutations: any = {
             authorObj.mountainPermissions > 5 ) ||
         authorObj.permissions === PermissionTypes.admin) {
         status = CreatedItemStatusEnum.auto;
+      } else if (authorObj.mountainPermissions !== null &&
+            authorObj.mountainPermissions === -1) {
+        return null;
       } else {
         status = CreatedItemStatusEnum.pending;
       }

--- a/src/server/graphql/schema/mutations/userMutations.ts
+++ b/src/server/graphql/schema/mutations/userMutations.ts
@@ -2,6 +2,7 @@
 import {
   GraphQLBoolean,
   GraphQLID,
+  GraphQLInt,
   GraphQLList,
   GraphQLNonNull,
   GraphQLString,
@@ -651,6 +652,27 @@ const userMutations: any = {
           $pull: { mountainNotes: { mountain: mountainId } },
         });
         return await User.findOne({_id: userId});
+      } catch (err) {
+        return err;
+      }
+    },
+  },
+  updateMountainPermissions: {
+    type: UserType,
+    args: {
+      id: { type: GraphQLNonNull(GraphQLID) },
+      mountainPermissions: { type: GraphQLInt },
+    },
+    async resolve(_unused: any,
+                  { id, mountainPermissions }: { id: string , mountainPermissions: number | null},
+                  {dataloaders}: {dataloaders: any}) {
+      try {
+        const user = await User.findOneAndUpdate(
+        { _id: id },
+        { mountainPermissions },
+        {new: true});
+        dataloaders.userLoader.clear(id).prime(id, user);
+        return user;
       } catch (err) {
         return err;
       }

--- a/src/server/graphql/schema/queryTypes/mountainType.ts
+++ b/src/server/graphql/schema/queryTypes/mountainType.ts
@@ -70,6 +70,12 @@ export const MountainFlag = new GraphQLEnumType({
     location: {
       value: 'location',
     },
+    elevation: {
+      value: 'elevation',
+    },
+    state: {
+      value: 'state',
+    },
     duplicate: {
       value: 'duplicate',
     },
@@ -81,6 +87,9 @@ export const MountainFlag = new GraphQLEnumType({
     },
     other: {
       value: 'other',
+    },
+    deleteRequest: {
+      value: 'deleteRequest',
     },
   },
 });

--- a/src/server/graphql/schema/queryTypes/mountainType.ts
+++ b/src/server/graphql/schema/queryTypes/mountainType.ts
@@ -1,4 +1,5 @@
 import {
+  GraphQLEnumType,
   GraphQLFloat,
   GraphQLID,
   GraphQLList,
@@ -9,6 +10,7 @@ import mongoose, { Schema } from 'mongoose';
 import { Mountain as IMountain } from '../../graphQLTypes';
 import PeakListType from './peakListType';
 import StateType from './stateType';
+import UserType from './userType';
 
 type MountainSchemaType = mongoose.Document & IMountain & {
   findState: (id: string) => any;
@@ -31,6 +33,12 @@ const MountainSchema = new Schema({
     type: Schema.Types.ObjectId,
     ref: 'list',
   }],
+  author: {
+    type: Schema.Types.ObjectId,
+    ref: 'user',
+  },
+  status: { type: String },
+  flag: { type: String },
 });
 
 MountainSchema.statics.findState = function(id: string) {
@@ -40,6 +48,42 @@ MountainSchema.statics.findState = function(id: string) {
 };
 
 export const Mountain: MountainModelType = mongoose.model<MountainModelType, any>('mountain', MountainSchema);
+
+export const CreatedItemStatus = new GraphQLEnumType({
+  name: 'CreatedItemStatus',
+  values: {
+    pending: {
+      value: 'pending',
+    },
+    auto: {
+      value: 'auto',
+    },
+    accepted: {
+      value: 'accepted',
+    },
+  },
+});
+
+export const MountainFlag = new GraphQLEnumType({
+  name: 'MountainFlag',
+  values: {
+    location: {
+      value: 'location',
+    },
+    duplicate: {
+      value: 'duplicate',
+    },
+    data: {
+      value: 'data',
+    },
+    abuse: {
+      value: 'abuse',
+    },
+    other: {
+      value: 'other',
+    },
+  },
+});
 
 const MountainType: any = new GraphQLObjectType({
   name:  'MountainType',
@@ -74,6 +118,26 @@ const MountainType: any = new GraphQLObjectType({
         }
       },
     },
+    author: {
+      type: UserType,
+      async resolve(parentValue, args, {dataloaders: {userLoader}}) {
+        try {
+          if (parentValue.author) {
+            const res = await userLoader.load(parentValue.author);
+            if (res._id.toString() !== parentValue.author.toString()) {
+              throw new Error('IDs do not match' + res);
+            }
+            return res;
+          } else {
+            return null;
+          }
+        } catch (err) {
+          return err;
+        }
+      },
+    },
+    status: { type: CreatedItemStatus },
+    flag: { type: MountainFlag },
   }),
 });
 

--- a/src/server/graphql/schema/queryTypes/userType.ts
+++ b/src/server/graphql/schema/queryTypes/userType.ts
@@ -1,6 +1,7 @@
 import {
   GraphQLBoolean,
   GraphQLID,
+  GraphQLInt,
   GraphQLList,
   GraphQLNonNull,
   GraphQLObjectType,
@@ -8,7 +9,7 @@ import {
 } from 'graphql';
 import mongoose, { Schema } from 'mongoose';
 import { User as IUser } from '../../graphQLTypes';
-import MountainType from './mountainType';
+import MountainType, {Mountain} from './mountainType';
 import PeakListType from './peakListType';
 
 type UserSchemaType = mongoose.Document & IUser;
@@ -67,6 +68,7 @@ const UserSchema = new Schema({
     },
     text: { type: String },
   }],
+  mountainPermissions: { type: Number },
 });
 
 export type UserModelType = mongoose.Model<UserSchemaType> & UserSchemaType;
@@ -260,6 +262,18 @@ const UserType: any = new GraphQLObjectType({
         }
       },
     },
+    authoredMountains: {
+      type: new GraphQLList(MountainType),
+      resolve(parentValue) {
+        try {
+          const { _id } = parentValue;
+          return Mountain.find({author: _id});
+        } catch (err) {
+          return err;
+        }
+      },
+    },
+    mountainPermissions: { type: GraphQLInt },
   }),
 });
 

--- a/src/server/graphql/schema/rootQueryType.ts
+++ b/src/server/graphql/schema/rootQueryType.ts
@@ -115,9 +115,13 @@ const RootQuery = new GraphQLObjectType({
     },
     mountain: {
       type: MountainType,
-      args: { id: { type: new GraphQLNonNull(GraphQLID) } },
+      args: { id: { type: GraphQLID } },
       resolve(parentValue, { id }) {
-        return Mountain.findById(id);
+        if (id === null) {
+          return null;
+        } else {
+          return Mountain.findById(id);
+        }
       },
     },
     state: {

--- a/src/server/graphql/schema/rootQueryType.ts
+++ b/src/server/graphql/schema/rootQueryType.ts
@@ -5,6 +5,7 @@ import {
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
+  GraphQLFloat,
 } from 'graphql';
 import MountainType, { Mountain } from './queryTypes/mountainType';
 import PeakListType, { PeakList } from './queryTypes/peakListType';
@@ -206,6 +207,22 @@ const RootQuery = new GraphQLObjectType({
           })
           .limit(nPerPage)
           .sort({ date: -1 });
+      },
+    },
+    nearbyMountains: {
+      type: new GraphQLList(MountainType),
+      args: {
+        latitude: { type: GraphQLNonNull(GraphQLFloat) },
+        longitude: { type: GraphQLNonNull(GraphQLFloat) },
+        latDistance: { type: GraphQLNonNull(GraphQLFloat) },
+        longDistance: { type: GraphQLNonNull(GraphQLFloat) },
+      },
+      resolve(parentValue, { latitude, longitude, latDistance, longDistance }:
+        {latitude: number, longitude: number, latDistance: number, longDistance: number}) {
+        return Mountain.find({
+          latitude: { $gt: latitude - latDistance, $lt: latitude + latDistance },
+          longitude: { $gt: longitude - longDistance, $lt: longitude + longDistance },
+        });
       },
     },
   }),

--- a/src/server/graphql/schema/rootQueryType.ts
+++ b/src/server/graphql/schema/rootQueryType.ts
@@ -7,14 +7,13 @@ import {
   GraphQLObjectType,
   GraphQLString,
 } from 'graphql';
+import { CreatedItemStatus } from '../graphQLTypes';
 import MountainType, { Mountain } from './queryTypes/mountainType';
 import PeakListType, { PeakList } from './queryTypes/peakListType';
 import RegionType, { Region } from './queryTypes/regionType';
 import StateType, { State } from './queryTypes/stateType';
 import TripReportType, { TripReport } from './queryTypes/tripReportType';
 import UserType, { User } from './queryTypes/userType';
-import { CreatedItemStatus } from '../graphQLTypes';
-
 
 const RootQuery = new GraphQLObjectType({
   name: 'RootQueryType',

--- a/src/server/graphql/schema/rootQueryType.ts
+++ b/src/server/graphql/schema/rootQueryType.ts
@@ -1,11 +1,11 @@
 import {
+  GraphQLFloat,
   GraphQLID,
   GraphQLInt,
   GraphQLList,
   GraphQLNonNull,
   GraphQLObjectType,
   GraphQLString,
-  GraphQLFloat,
 } from 'graphql';
 import MountainType, { Mountain } from './queryTypes/mountainType';
 import PeakListType, { PeakList } from './queryTypes/peakListType';

--- a/src/server/graphql/schema/rootQueryType.ts
+++ b/src/server/graphql/schema/rootQueryType.ts
@@ -13,6 +13,8 @@ import RegionType, { Region } from './queryTypes/regionType';
 import StateType, { State } from './queryTypes/stateType';
 import TripReportType, { TripReport } from './queryTypes/tripReportType';
 import UserType, { User } from './queryTypes/userType';
+import { CreatedItemStatus } from '../graphQLTypes';
+
 
 const RootQuery = new GraphQLObjectType({
   name: 'RootQueryType',
@@ -227,6 +229,18 @@ const RootQuery = new GraphQLObjectType({
           latitude: { $gt: latitude - latDistance, $lt: latitude + latDistance },
           longitude: { $gt: longitude - longDistance, $lt: longitude + longDistance },
         });
+      },
+    },
+    flaggedMountains: {
+      type: new GraphQLList(MountainType),
+      resolve() {
+        return Mountain.find({ flag: { $ne: null } });
+      },
+    },
+    pendingMountains: {
+      type: new GraphQLList(MountainType),
+      resolve() {
+        return Mountain.find({ status: { $eq: CreatedItemStatus.pending } });
       },
     },
   }),

--- a/src/server/notifications/email.ts
+++ b/src/server/notifications/email.ts
@@ -5,6 +5,9 @@ import ascentEmailTemplate, {
 } from './emailTemplates/ascentEmail';
 import ascentInviteEmailTemplate from './emailTemplates/ascentInviteEmail';
 import friendRequestEmailTemplate from './emailTemplates/friendRequestEmail';
+import genericEmailTemplate, {
+  GenericEmailNotificationInput,
+} from './emailTemplates/genericEmail';
 import welcomeEmailTemplate from './emailTemplates/welcomeEmail';
 
 const transport = createTransport({
@@ -99,6 +102,24 @@ export const sendAcceptFriendRequestEmailNotification = (
     to: userEmail,
     subject: `${userName} is now your friend on Wilderlist`,
     html: acceptFriendRequestEmailTemplate({userName, userEmail, userId}),
+  };
+  transport.sendMail(mailOptions, (error) => {
+    if (error) {
+      console.error(error);
+    }
+    transport.close();
+  });
+};
+
+export const sendGenericEmailNotification = (input: GenericEmailNotificationInput) => {
+  const {
+    userEmail, subject,
+  } = input;
+  const mailOptions = {
+    from: `Kyle via Wilderlist <${process.env.GMAIL_USERNAME}>`,
+    to: userEmail,
+    subject,
+    html: genericEmailTemplate(input),
   };
   transport.sendMail(mailOptions, (error) => {
     if (error) {

--- a/src/server/notifications/emailTemplates/genericEmail.ts
+++ b/src/server/notifications/emailTemplates/genericEmail.ts
@@ -1,0 +1,41 @@
+/* tslint:disable:max-line-length */
+
+export interface GenericEmailNotificationInput {
+  userEmail: string;
+  subject: string;
+  title: string;
+  content: string;
+  ctaText: string;
+  ctaLink: string;
+}
+
+export default (input: GenericEmailNotificationInput) => {
+  const {
+    userEmail, title, content, ctaText, ctaLink,
+  } = input;
+  return `
+  <div style="max-width: 450px; margin: auto;font-family: Arial, sans-serif; line-height: 1.4;color: #333333;">
+    <div style="text-align: center">
+      <img style="max-width: 250px; display:inline-block;" src="https://www.wilderlist.app/wilderlist-logo.png" />
+    </div>
+    <h1 style="text-align: center;font-size: 28px;">${title}</h1>
+    <div style="font-size: 17px;line-height: 1.7;">${content}</div>
+    <div style="text-align: center;">
+      <a href="${ctaLink}" style="display: inline-block;padding: 8px 18px;border-radius: 4px;color:#fff;background-color:#668434;text-decoration: none;">
+        ${ctaText}
+      </a>
+    </div>
+    <img style="max-width: 100%; margin-top: 60px;" src="https://www.wilderlist.app/mountain-range.png" />
+    <hr style="margin-top: 20px;"/>
+    <div style="color: #7c7c7c; padding: 10px; text-align: center; margin-top: 20px; line-height: 1.5;">
+      <p style="font-size: 12px">
+        393 Broadway, Cambridge, MA 02139 | 508-517-6476
+        <br /><a href="https://www.wilderlist.app/" style="color:#2b5b37;">Wilderlist</a> | <a href="mailto:wilderlistapp@gmail.com" style="color:#2b5b37;">wilderlistapp@gmail.com</a>
+        <br />
+        <br />This message was sent to <a href="mailto:${userEmail}" style="color:#2b5b37;">${userEmail}</a> by <a href="https://www.wilderlist.app/" style="color:#2b5b37;">Wilderlist</a>.
+        <br ><a href="https://www.wilderlist.app/user-settings" style="color:#2b5b37;">Unsubscribe through your Wilderlist account here</a>.
+      </p>
+    </div>
+  </div>
+  `;
+};

--- a/src/server/notifications/index.ts
+++ b/src/server/notifications/index.ts
@@ -1,6 +1,9 @@
 import { Express } from 'express';
 import { formatStringDate } from '../graphql/Utils';
-import { sendAscentInviteEmailNotification } from './email';
+import {
+  sendAscentInviteEmailNotification,
+  sendGenericEmailNotification,
+} from './email';
 
 const notificationRoutes = (app: Express) => {
   app.get('/api/ascent-invite', (req, res) => {
@@ -14,6 +17,22 @@ const notificationRoutes = (app: Express) => {
           user: req.user.name,
           userEmail: email,
           date: formatStringDate(date),
+        });
+      }
+    }
+    res.send();
+  });
+  app.get('/api/send-email', (req, res) => {
+    if (req && req.query && req.user) {
+      const {
+        userEmail, subject, title,
+        content, ctaText, ctaLink,
+      } = req.query;
+      if (userEmail && subject && title &&
+          content && ctaText && ctaLink) {
+        sendGenericEmailNotification({
+          userEmail, subject, title,
+          content, ctaText, ctaLink,
         });
       }
     }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -62,6 +62,7 @@ mongoose.connect(process.env.MONGO_URI, {
   dbName: process.env.MONGO_DATABASE_NAME,
   useCreateIndex: true,
   useNewUrlParser: true,
+  useUnifiedTopology: true,
 });
 
 mongoose.connection


### PR DESCRIPTION
Implement functionality to allow users to add and edit mountains. Other users can flag mountains that they believe are in error. Admin panel updated with ability to quickly approve pending mountain additions, review flags, and grant/revoke/reset a users mountain adding privileges.

Trip report styling has been improved. Carriage returns are now kept when the copy is outputted, and the max character length before "Read More" appears has increased, and is based on how recent a report is. Older reports have a lower character count. Anchor has also been added to both the trip report container as well as to individual trip reports so that they may be linked.